### PR TITLE
List cds and cms to modify in the "modify" sheets

### DIFF
--- a/universal_analytics/modifyUACustomDefinitions.js
+++ b/universal_analytics/modifyUACustomDefinitions.js
@@ -257,7 +257,7 @@ function writeUACustomDefinitionModificationToSheet(
  */
 function writeCustomDimensionDestinationPropertiesToSheet() {
   writeDestinationPropertiesToSheet(
-    sheetsMeta.ua.modifyCdsResults.sheetName,
+    sheetsMeta.ua.modifyCdsDestinationProperties.sheetName,
     sheetsMeta.ua.modifyCdsDestinationProperties
   );
 }
@@ -290,7 +290,7 @@ function modifyCustomDimensions() {
  */
 function writeCustomMetricDestinationPropertiesToSheet() {
   writeDestinationPropertiesToSheet(
-    sheetsMeta.ua.modifyCmsResults.sheetName,
+    sheetsMeta.ua.modifyCmsDestinationProperties.sheetName,
     sheetsMeta.ua.modifyCmsDestinationProperties
   );
 }


### PR DESCRIPTION
Currently listing the destination properties for cds and cms adds them to the modify - results sheets rather than listing them in the modify sheet. These changes list them in the modify sheet, allowing to select a destination property there.